### PR TITLE
Rename elastic_cache to elasticache to fix a behaviour change in Click 7.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Templates samples
 - https://github.com/instacart/cwam/blob/master/templates/alb.template.yml
 - https://github.com/instacart/cwam/blob/master/templates/rds.template.yml
 - https://github.com/instacart/cwam/blob/master/templates/kinesis.template.yml
-- https://github.com/instacart/cwam/blob/master/templates/elastic_cache.template.yml
+- https://github.com/instacart/cwam/blob/master/templates/elasticache.template.yml
 
 Human interaction
 ~~~~~~~~~~~~~~~~~
@@ -111,7 +111,7 @@ Subcommands
 
     Commands:
       alb
-      elastic_cache
+      elasticache
       elb
       kinesis
       rds

--- a/cwam/cli.py
+++ b/cwam/cli.py
@@ -16,7 +16,7 @@ from .rds import RDS
 from .ec2 import EC2
 from .ecs import ECS
 from .kinesis import Kinesis
-from .elastic_cache import ElastiCache
+from .elasticache import ElastiCache
 from .utils import json_serializer
 
 # Fix Python 2.x vs 3.x.
@@ -42,7 +42,7 @@ KINESIS_TMP_FILE = "{}/{}/{}".format(expanduser("~"),
                                      'kinesis.template.yml')
 ELASTIC_CACHE_TMP_FILE = "{}/{}/{}".format(expanduser("~"),
                                            '.cwam',
-                                           'elastic_cache.template.yml')
+                                           'elasticache.template.yml')
 EC2_TMP_FILE = "{}/{}/{}".format(expanduser("~"),
                                  '.cwam',
                                  'ec2.template.yml')
@@ -617,13 +617,13 @@ def pgbouncer_remote_alarms(ctx, template, no_human, no_script):
 
 @main.group()
 @click.pass_context
-def elastic_cache(ctx):
+def elasticache(ctx):
     pass
 
 
-@elastic_cache.command(name='list')  # noqa: F811
+@elasticache.command(name='list')  # noqa: F811
 @click.pass_context
-def elastic_cache_list(ctx):
+def elasticache_list(ctx):
     """List ElastiCache clusters."""
     instances = ElastiCache(aws_access_key_id=ctx.obj['AWS_ACCESS_KEY_ID'],
                             aws_access_secret_key=ctx.obj['AWS_SECRET_ACCESS_KEY'],  # noqa E501
@@ -634,17 +634,17 @@ def elastic_cache_list(ctx):
         click.echo(instance)
 
 
-@elastic_cache.command(name='create')  # noqa: F811
+@elasticache.command(name='create')  # noqa: F811
 @click.pass_context
 @click.option('--template', '-t', type=UNICODE_TYPE,
               default=ELASTIC_CACHE_TMP_FILE,
               help='Path to template file. Default: {}.'.format(ELASTIC_CACHE_TMP_FILE))  # noqa E501
 @click.option('--simulate', '-s', is_flag=True, default=False,
               help='Simulate only. Do not take actions')
-def elastic_cache_create(ctx, template, simulate):
+def elasticache_create(ctx, template, simulate):
     """Create alarms configured in --template file"""
     if os.path.isfile(template):
-        template = parse_yml(ctx, template)['elastic_caches']
+        template = parse_yml(ctx, template)['elasticaches']
         namespace = template.get('namespace')
         prefix = template.get('prefix')
         only = template.get('only')
@@ -657,12 +657,12 @@ def elastic_cache_create(ctx, template, simulate):
         ctx.fail('Conf file not found. Make sure --template is a valid path.')
 
     if len(alarms) > 0:
-        elastic_cache = ElastiCache(aws_access_key_id=ctx.obj['AWS_ACCESS_KEY_ID'],  # noqa E501
+        elasticache = ElastiCache(aws_access_key_id=ctx.obj['AWS_ACCESS_KEY_ID'],  # noqa E501
                                     aws_access_secret_key=ctx.obj['AWS_SECRET_ACCESS_KEY'],  # noqa E501
                                     aws_session_token=ctx.obj['AWS_SESSION_TOKEN'],  # noqa E501
                                     aws_default_region=ctx.obj['AWS_DEFAULT_REGION'],  # noqa E501
                                     debug=ctx.obj['DEBUG'])
-        elastic_cache.create(objects=parse_alarms(namespace, alarms),
+        elasticache.create(objects=parse_alarms(namespace, alarms),
                              namespace=namespace,
                              prefix=prefix,
                              default=parse_default_alarm(namespace, default),
@@ -675,20 +675,20 @@ def elastic_cache_create(ctx, template, simulate):
         click.echo('No alarms found.')
 
 
-@elastic_cache.command(name='local-alarms')  # noqa: F811
+@elasticache.command(name='local-alarms')  # noqa: F811
 @click.pass_context
 @click.option('--template', '-t', type=UNICODE_TYPE,
               default=ELASTIC_CACHE_TMP_FILE,
               help='Path to template file. Default: {}.'.format(ELASTIC_CACHE_TMP_FILE))  # noqa E501
-def elastic_cache_local_alarms(ctx, template):
-    namespace, alarms = parse_alarms_yml(ctx, 'elastic_caches', template)
+def elasticache_local_alarms(ctx, template):
+    namespace, alarms = parse_alarms_yml(ctx, 'elasticaches', template)
     for k, v in parse_alarms(namespace, alarms).items():
         click.echo(k)
         for alarm in v:
             click.echo(str(alarm))
 
 
-@elastic_cache.command(name='remote-alarms')  # noqa: F811
+@elasticache.command(name='remote-alarms')  # noqa: F811
 @click.pass_context
 @click.option('--template', '-t', type=UNICODE_TYPE,
               default=ELASTIC_CACHE_TMP_FILE,
@@ -697,22 +697,22 @@ def elastic_cache_local_alarms(ctx, template):
               help='Show only human alarms.')
 @click.option('--no-script', '-s', is_flag=True, default=False,
               help='Show only script alarms.')
-def elastic_cache_remote_alarms(ctx, template, no_human, no_script):
+def elasticache_remote_alarms(ctx, template, no_human, no_script):
     """List alarms configured on AWS"""
     if os.path.isfile(template):
-        template = parse_yml(ctx, template)['elastic_caches']
+        template = parse_yml(ctx, template)['elasticaches']
         namespace = template.get('namespace')
         prefix = template.get('prefix')
     else:
         namespace = None
         prefix = None
 
-    elastic_cache = ElastiCache(aws_access_key_id=ctx.obj['AWS_ACCESS_KEY_ID'],  # noqa E501
+    elasticache = ElastiCache(aws_access_key_id=ctx.obj['AWS_ACCESS_KEY_ID'],  # noqa E501
                                 aws_access_secret_key=ctx.obj['AWS_SECRET_ACCESS_KEY'],  # noqa E501
                                 aws_session_token=ctx.obj['AWS_SESSION_TOKEN'],  # noqa E501
                                 aws_default_region=ctx.obj['AWS_DEFAULT_REGION'],  # noqa E501
                                 debug=ctx.obj['DEBUG'])
-    human_alarms, script_alarms = elastic_cache.remote_alarms(namespace=namespace,  # noqa E501
+    human_alarms, script_alarms = elasticache.remote_alarms(namespace=namespace,  # noqa E501
                                                               prefix=prefix)
 
     if not no_human:

--- a/cwam/cli.py
+++ b/cwam/cli.py
@@ -644,7 +644,7 @@ def elasticache_list(ctx):
 def elasticache_create(ctx, template, simulate):
     """Create alarms configured in --template file"""
     if os.path.isfile(template):
-        template = parse_yml(ctx, template)['elasticaches']
+        template = parse_yml(ctx, template)['elasticache']
         namespace = template.get('namespace')
         prefix = template.get('prefix')
         only = template.get('only')
@@ -681,7 +681,7 @@ def elasticache_create(ctx, template, simulate):
               default=ELASTIC_CACHE_TMP_FILE,
               help='Path to template file. Default: {}.'.format(ELASTIC_CACHE_TMP_FILE))  # noqa E501
 def elasticache_local_alarms(ctx, template):
-    namespace, alarms = parse_alarms_yml(ctx, 'elasticaches', template)
+    namespace, alarms = parse_alarms_yml(ctx, 'elasticache', template)
     for k, v in parse_alarms(namespace, alarms).items():
         click.echo(k)
         for alarm in v:
@@ -700,7 +700,7 @@ def elasticache_local_alarms(ctx, template):
 def elasticache_remote_alarms(ctx, template, no_human, no_script):
     """List alarms configured on AWS"""
     if os.path.isfile(template):
-        template = parse_yml(ctx, template)['elasticaches']
+        template = parse_yml(ctx, template)['elasticache']
         namespace = template.get('namespace')
         prefix = template.get('prefix')
     else:

--- a/cwam/elasticache.py
+++ b/cwam/elasticache.py
@@ -76,7 +76,7 @@ class ElastiCache(CloudWatch, object):
                                           debug=debug)
         self.client = self.session.client('elasticache')
 
-    def _describe_elastic_caches(self):
+    def _describe_elasticaches(self):
         caches = []
         pager = self.client.get_paginator('describe_cache_clusters')
         for page in pager.paginate():
@@ -85,7 +85,7 @@ class ElastiCache(CloudWatch, object):
         return caches
 
     def list(self):
-        return self._describe_elastic_caches()
+        return self._describe_elasticaches()
 
     def remote_alarms(self, namespace=DEFAULT_NAMESPACE,
                       prefix=ALARM_NAME_PREFIX):
@@ -100,7 +100,7 @@ class ElastiCache(CloudWatch, object):
         if exclude is not None and only is not None:
             raise "Exlude and Only option are mutually exclusive."
 
-        instances = self._describe_elastic_caches()
+        instances = self._describe_elasticaches()
 
         redis_instances = [i for i in instances if i.engine == 'redis']
         memcached_instances = [i for i in instances if i not in redis_instances] # noqa E501

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,6 @@ flake8==2.6.0
 tox==2.3.1
 coverage==4.1
 Sphinx==1.4.8
-Click>=6.7
+Click>=7.0
 boto3>=1.4.3
 dictdiffer>=0.6.1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ test_requirements = [
 
 setup(
     name='cwam',
-    version='1.0.0',
+    version='1.0.1',
     description="Easy way to create default CloudWatch Alarms.",
     long_description=readme + '\n\n' + history,
     author="Quentin Rousseau",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'Click>=6.7',
+    'Click>=7.0',
     'boto3>=1.4.3',
     'dictdiffer>=0.6.1',
     'PyYAML>=3.12'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ test_requirements = [
 
 setup(
     name='cwam',
-    version='1.0.1',
+    version='2.0',
     description="Easy way to create default CloudWatch Alarms.",
     long_description=readme + '\n\n' + history,
     author="Quentin Rousseau",

--- a/templates/elastic_cache.template.yml
+++ b/templates/elastic_cache.template.yml
@@ -19,7 +19,7 @@
 # Redis
 # Cf. http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CacheMetrics.Redis.html
 
-elastic_caches:
+elasticaches:
   namespace: AWS/ElastiCache
   prefix: Cache
   # only:
@@ -64,7 +64,7 @@ elastic_caches:
           EvaluationPeriods: 1
           Period: 60
           Threshold: 1000000000
-    my_elastic_cache_identifier:
+    my_elasticache_identifier:
       - HighCPUUtilization:
           MetricName: CPUUtilization
           Statistic: Average

--- a/templates/elastic_cache.template.yml
+++ b/templates/elastic_cache.template.yml
@@ -19,7 +19,7 @@
 # Redis
 # Cf. http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CacheMetrics.Redis.html
 
-elasticaches:
+elasticache:
   namespace: AWS/ElastiCache
   prefix: Cache
   # only:


### PR DESCRIPTION
This is causing CWAM runs to fail because the command name changed with the latest version of Click, the library used for cli generation.

* Underscores are converted to dashes starting in Click 7.0  https://click.palletsprojects.com/en/7.x/changelog/
* This is the right name for the service anyways

Link to the original issue: https://bugs.instacart.tools/issues/10282

