### PR TITLE
updates yaml load to use yaml.SafeLoader

### DIFF
--- a/cwam/cli.py
+++ b/cwam/cli.py
@@ -64,7 +64,7 @@ def json_dumps(dict, pretty=False):
 def parse_yml(ctx, path):
     with open(path, 'r') as stream:
         try:
-            content = yaml.load(stream)
+            content = yaml.safe_load(stream)
         except yaml.YAMLError as e:
             ctx.fail(e)
         return content


### PR DESCRIPTION
Prevents a `yaml.YAMLLoadWarning` because the default `yaml.load` function is unsafe. This will reduce log noise for CWAM invocations. See https://msg.pyyaml.org/load for details.

Ran into this while debugging https://instacart.atlassian.net/browse/ISC-1249
cc @instacart/infra to review, please.
