### PR TITLE
Only use defaults when the current Dimensions are unset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@
 # This file will be regenerated if you run travis_pypi_setup.py
 
 language: python
-python: 3.6
+python: 3.7
 
 env:
+  - TOXENV=py37
   - TOXENV=py36
-  - TOXENV=py34
-  - TOXENV=py33
   - TOXENV=py27
   - TOXENV=py26
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ python: 3.7
 
 env:
   - TOXENV=py37
-  - TOXENV=py36
   - TOXENV=py27
-  - TOXENV=py26
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox

--- a/cwam/utils.py
+++ b/cwam/utils.py
@@ -99,12 +99,7 @@ def resolved_dict(name, instance, original, default, namespace=None,
     if prefix is not None:
         params['AlarmName'] = '{}/{}/{}'.format(prefix, instance.name, name)
 
-    if params.get('Dimensions') and len(params.get('Dimensions')) > 0:
-        for dim in params['Dimensions']:
-            value = dim.get('Value')
-            if value:
-                dim['Value'] = instance.dict().get(value)
-    else:
+    if not params.get('Dimensions') or len(params.get('Dimensions')) == 0:
         params['Dimensions'] = instance.default_dimensions()
 
     for attr in params:


### PR DESCRIPTION
When `Dimensions` is defined, `dim['Value'] = instance.dict().get(value)` was setting the `dim['Value']` to None