### PR TITLE
allow yaml parse errors to show a proper traceback

### DIFF
--- a/cwam/cli.py
+++ b/cwam/cli.py
@@ -63,11 +63,7 @@ def json_dumps(dict, pretty=False):
 
 def parse_yml(ctx, path):
     with open(path, 'r') as stream:
-        try:
-            content = yaml.safe_load(stream)
-        except yaml.YAMLError as e:
-            ctx.fail(e)
-        return content
+        return yaml.safe_load(stream)
 
 
 def parse_exclude_only(infos):


### PR DESCRIPTION
@mmontagna reported a stack trace that was not very helpful:
```
Creating PgBouncer Alarms
Traceback (most recent call last):
  File "/usr/local/lib/pyenv/versions/2.7.16/bin/cwam", line 11, in <module>
    load_entry_point('cwam==2.1', 'console_scripts', 'cwam')()
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/cwam/cli.py", line 533, in pgbouncer_create
    template = parse_yml(ctx, template)['pgbouncer']
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/cwam/cli.py", line 69, in parse_yml
    ctx.fail(e)
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/click/core.py", line 496, in fail
    raise UsageError(message, self)
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/click/exceptions.py", line 54, in __init__
    ClickException.__init__(self, message)
  File "/usr/local/lib/pyenv/versions/2.7.16/lib/python2.7/site-packages/click/exceptions.py", line 21, in __init__
    ctor_msg = ctor_msg.encode('utf-8')
AttributeError: 'ParserError' object has no attribute 'encode'
```
Since this crashes the program anyways, we should just allow the yaml parse error to fall through, instead of passing an exception to `ctx.fail` and losing the original stack trace.